### PR TITLE
feat: 検索を高速化するためにインデックスを張る

### DIFF
--- a/common/src/main/scala/infrastructure/Tables.scala
+++ b/common/src/main/scala/infrastructure/Tables.scala
@@ -52,6 +52,8 @@ trait Tables {
 
     /** Uniqueness Index over (url,settingsId) (database name CONSTRAINT_INDEX_E) */
     val index1 = index("CONSTRAINT_INDEX_E", (url, settingsId), unique=true)
+    /** Index over (processed) (database name INDEX_E) */
+    val index2 = index("INDEX_E", processed)
   }
   /** Collection-like TableQuery object for table Articles */
   lazy val Articles = new TableQuery(tag => new Articles(tag))

--- a/migration/src/main/resources/db/migration/V3__Add_index.sql
+++ b/migration/src/main/resources/db/migration/V3__Add_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ON articles(processed);


### PR DESCRIPTION
- processed のカーディナリティは低いが大部分のレコードが処理済みになるはずなのでインデックスを張る効果はあると考える (未計測)